### PR TITLE
Fix beforeEach usage in labelManager tests

### DIFF
--- a/tests/labelManager.test.ts
+++ b/tests/labelManager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as core from '@actions/core';
 import { labelsFromMetadata, ensureLabelExists } from '../src/core/labelManager';
 
@@ -55,6 +55,4 @@ describe('ensureLabelExists', () => {
     });
   });
 });
-function beforeEach(setupFunction: () => void): void {
-  setupFunction();
-}
+


### PR DESCRIPTION
## Summary
- use beforeEach hook from vitest instead of custom function
- remove custom helper

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_683f5708d7a883258eddbb5f2f7eb921