### PR TITLE
Add ignore list to directory parsers

### DIFF
--- a/src/parser/extractTodosFromDir.ts
+++ b/src/parser/extractTodosFromDir.ts
@@ -4,6 +4,7 @@ import { extractTodosFromFile } from './extractTodos';
 import { TodoItem } from './types';
 
 const SUPPORTED_EXTENSIONS = ['.ts', '.js', '.py', '.go', '.java', '.rb', '.sh', '.html', '.xml'];
+const IGNORED_DIRS = ['node_modules', 'dist', 'coverage'];
 
 export function extractTodosFromDir(dirPath: string): TodoItem[] {
   const todos: TodoItem[] = [];
@@ -15,6 +16,7 @@ export function extractTodosFromDir(dirPath: string): TodoItem[] {
       const fullPath = path.join(currentPath, entry.name);
 
       if (entry.isDirectory()) {
+        if (IGNORED_DIRS.includes(entry.name)) continue;
         walk(fullPath);
       } else if (entry.isFile()) {
         const ext = path.extname(entry.name);

--- a/src/parser/extractTodosWithStructuredTagsFromDir.ts
+++ b/src/parser/extractTodosWithStructuredTagsFromDir.ts
@@ -3,7 +3,9 @@ import path from 'path';
 import fs from 'fs';
 import { TodoItem } from './types';
 import { extractTodosWithStructuredTags } from './extractTodosWithStructuredTags';
-import { isTextFile } from '../utils/isTextFile'; 
+import { isTextFile } from '../utils/isTextFile';
+
+const IGNORED_DIRS = ['node_modules', 'dist', 'coverage'];
 
 
 export function extractTodosWithStructuredTagsFromDir(dir: string): TodoItem[] {
@@ -15,6 +17,7 @@ export function extractTodosWithStructuredTagsFromDir(dir: string): TodoItem[] {
     for (const entry of entries) {
       const fullPath = path.join(currentPath, entry.name);
       if (entry.isDirectory()) {
+        if (IGNORED_DIRS.includes(entry.name)) continue;
         walk(fullPath);
       } else if (entry.isFile()) {
         try {

--- a/tests/extractTodosFromDir.test.ts
+++ b/tests/extractTodosFromDir.test.ts
@@ -25,4 +25,10 @@ describe('extractTodosFromDir', () => {
     expect(typeof one?.line).toBe('number');
     expect(one?.line).toBeGreaterThan(0);
   });
+
+  it('should ignore files inside ignored directories', () => {
+    const todos = extractTodosFromDir(base);
+    const ignored = todos.find(t => t.text.includes('Should not be picked up'));
+    expect(ignored).toBeUndefined();
+  });
 });

--- a/tests/fixtures/node_modules/ignore.js
+++ b/tests/fixtures/node_modules/ignore.js
@@ -1,0 +1,2 @@
+// TODO: Should not be picked up
+console.log('ignore');


### PR DESCRIPTION
## Summary
- skip common generated folders when walking directories
- test that ignored dirs aren't parsed

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_683f5c832134832592c5f6dd9b7442ba