### PR TITLE
Add text file check in structured TODO extraction

### DIFF
--- a/src/parser/extractTodosWithStructuredTagsFromDir.ts
+++ b/src/parser/extractTodosWithStructuredTagsFromDir.ts
@@ -20,11 +20,13 @@ export function extractTodosWithStructuredTagsFromDir(dir: string): TodoItem[] {
         if (IGNORED_DIRS.includes(entry.name)) continue;
         walk(fullPath);
       } else if (entry.isFile()) {
-        try {
-          const fileTodos = extractTodosWithStructuredTags(fullPath);
-          todos.push(...fileTodos);
-        } catch {
-          // opcional: log de ficheiros ignorados
+        if (isTextFile(fullPath)) {
+          try {
+            const fileTodos = extractTodosWithStructuredTags(fullPath);
+            todos.push(...fileTodos);
+          } catch {
+            // opcional: log de ficheiros ignorados
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- only extract TODOs from directories when files are text-based

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_683f5e175234832587991ced65ca3bc5