### PR TITLE
Normalize tags in parser

### DIFF
--- a/src/parser/extractTodos.ts
+++ b/src/parser/extractTodos.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { TodoItem } from './types';
+import { normalizeTag } from '../utils/isTextFile';
 
 const COMMENT_PATTERNS = [
   { ext: ['.ts', '.js', '.java', '.go'], pattern: /^\s*\/\/\s*(.*)$/ },
@@ -37,8 +38,9 @@ export function extractTodosFromFile(filePath: string): TodoItem[] {
       const comment = commentMatch[1];
       const tagMatch = comment.match(TAG_REGEX);
       if (tagMatch) {
-        const [_, tag, metaRaw, text] = tagMatch;
+        const [_, rawTag, metaRaw, text] = tagMatch;
         const metadata = metaRaw ? extractMetadata(metaRaw) : undefined;
+        const tag = normalizeTag(rawTag) ?? rawTag;
         todos.push({
           file: filePath,
           line: idx + 1,

--- a/src/parser/extractTodosFromContent.ts
+++ b/src/parser/extractTodosFromContent.ts
@@ -1,6 +1,7 @@
 // src/parser/extractTodosFromContent.ts
 
 import { TodoItem } from './types';
+import { normalizeTag } from '../utils/isTextFile';
 
 const COMMENT_PATTERNS = [
   { ext: ['.ts', '.js', '.java', '.go'], pattern: /^\s*\/\/\s*(.*)$/ },
@@ -36,8 +37,9 @@ export function extractTodosFromString(content: string, ext: string): TodoItem[]
       const comment = commentMatch[1];
       const tagMatch = comment.match(TAG_REGEX);
       if (tagMatch) {
-        const [_, tag, metaRaw, text] = tagMatch;
+        const [_, rawTag, metaRaw, text] = tagMatch;
         const metadata = metaRaw ? extractMetadata(metaRaw) : undefined;
+        const tag = normalizeTag(rawTag) ?? rawTag;
         todos.push({
           file: `inline${ext}`,
           line: idx + 1,

--- a/tests/extractTodosFromContent.test.ts
+++ b/tests/extractTodosFromContent.test.ts
@@ -28,4 +28,13 @@ describe('extractTodosFromString', () => {
       due: '2025-06-01'
     });
   });
+
+  it('normalizes localized tags', () => {
+    const content = `// À FAIRE: tarefa\n# À CORRIGER: problema`;
+    const jsTodos = extractTodosFromString(content, '.js');
+    const pyTodos = extractTodosFromString(content, '.py');
+
+    expect(jsTodos[0].tag).toBe('TODO');
+    expect(pyTodos[0].tag).toBe('FIXME');
+  });
 });


### PR DESCRIPTION
## Summary
- normalize tags while extracting TODOs
- cover localized tags in extractTodosFromContent tests

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_683f5e52a5088325b732a615a8f09564