### PR TITLE
Add limit input docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ jobs:
         uses: ./
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          limit: 5
 ```
 
 ## 📝 Example TODOs
@@ -73,7 +74,7 @@ If a label like `priority:high` or `due:2025-06-01` doesn't exist, it will be au
 
 ## 📌 Notes
 
-- Max **5 issues** are created per run to avoid rate limiting
+ - Max **5 issues** are created per run to avoid rate limiting (configurable via the `limit` input)
 - **Duplicate detection** is not yet implemented _(coming soon)_
 - All labels are **auto-created with default colors** if missing
 

--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,11 @@ inputs:
     required: false
     description: Email used in conjunction with the Jira API token
 
+  limit:
+    required: false
+    description: Maximum number of issues to create
+    default: '5'
+
 runs:
   using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
## Summary
- document `limit` input in action.yml
- mention `limit` usage in README

## Testing
- `yarn test` *(fails: package missing)*
- `yarn install` *(fails: network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_683f5f9c11cc8325802c63e348221b19