### PR TITLE
Automate version bump on merge

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,0 +1,38 @@
+name: Bump Package Version
+
+on:
+  pull_request:
+    branches: [main]
+    types: [closed]
+
+jobs:
+  bump-version:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Bump version
+        run: yarn bump-version
+
+      - name: Commit and push changes
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json
+          git diff --cached --quiet && echo "No version change." || git commit -m "chore(release): bump version [skip ci]"
+          git push

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "prepare": "yarn ncc build src/ActionMain.ts -o dist",
     "changelog": "ts-node scripts/generateChangelog.ts",
     "build:dist": "ncc build src/ActionMain.ts -o dist",
-    "check-version": "ts-node scripts/checkVersionTag.ts"
+    "check-version": "ts-node scripts/checkVersionTag.ts",
+    "bump-version": "ts-node scripts/bumpVersion.ts"
   },
   "keywords": [
     "github-action",

--- a/scripts/bumpVersion.ts
+++ b/scripts/bumpVersion.ts
@@ -1,0 +1,33 @@
+import fs from 'fs';
+
+/**
+ * Increment the patch component of a semantic version string.
+ *
+ * @param version - Existing semantic version (e.g., "1.2.3").
+ * @returns New version string with the patch number incremented.
+ */
+function bumpPatchVersion(version: string): string {
+  const [major, minor, patch] = version.split('.').map(Number);
+  return `${major}.${minor}.${patch + 1}`;
+}
+
+/**
+ * Read package.json, update its version field, and persist the change.
+ *
+ * @param filePath - Path to the package.json file.
+ */
+function updatePackageVersion(filePath: string): void {
+  const pkg = JSON.parse(fs.readFileSync(filePath, 'utf8')) as { version: string };
+  const newVersion = bumpPatchVersion(pkg.version);
+
+  // Update version in memory
+  pkg.version = newVersion;
+
+  // Write updated package.json back to disk, preserving formatting
+  fs.writeFileSync(filePath, JSON.stringify(pkg, null, 2) + '\n', 'utf8');
+  console.log(`\u2705 Updated version to ${newVersion}`);
+}
+
+(function main() {
+  updatePackageVersion('package.json');
+})();


### PR DESCRIPTION
## Summary
- add a script to bump the patch version in package.json
- expose `bump-version` npm script
- create a workflow that bumps the package version after merging to main

## Testing
- `yarn install`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_685458e348548325a4940bf17284b62c