### PR TITLE
ci(release): auto-create release after version bump

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -30,6 +30,8 @@ jobs:
         run: yarn bump-version
 
       - name: Commit and push changes
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
             git config --global user.name "github-actions[bot]"
             git config --global user.email "github-actions[bot]@users.noreply.github.com"
@@ -42,4 +44,9 @@ jobs:
               VERSION=$(node -p "require('./package.json').version")
               git tag "v${VERSION}"
               git push origin "v${VERSION}"
+              if gh release view "v${VERSION}" >/dev/null 2>&1; then
+                echo "Release v${VERSION} already exists."
+              else
+                gh release create "v${VERSION}" --title "v${VERSION}" --generate-notes
+              fi
             fi


### PR DESCRIPTION
## Summary
- update Bump Package Version workflow to publish a GitHub Release immediately after pushing the new version tag
- add idempotency check so reruns do not fail if the release already exists

## Why
- currently the workflow only bumps version + tags, requiring manual release creation
- this change makes releases automatic

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically creates a GitHub Release right after pushing the version tag in the `Bump Package Version` workflow. Adds an idempotency check so reruns don’t fail if the release already exists.

- **New Features**
  - After tagging `v{VERSION}`, creates a release with generated notes via `gh release create`.
  - Skips creation if the release exists using `gh release view`, and sets `GH_TOKEN` for CLI auth.

<sup>Written for commit d92438d8b69bd8391999a8e7690ac2b32b5d0da2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

