### PR TITLE
fix(ci): stabilize post-merge workflows install mode

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -27,7 +27,9 @@ jobs:
         run: corepack enable
 
       - name: Install dependencies
-        run: yarn install
+        env:
+          YARN_ENABLE_HARDENED_MODE: "0"
+        run: yarn install --no-immutable
 
       - name: Bump version
         run: yarn bump-version

--- a/.github/workflows/todo.yml
+++ b/.github/workflows/todo.yml
@@ -66,7 +66,9 @@ jobs:
             echo "::warning::PERSONAL_ACCESS_TOKEN is not set. Falling back to GITHUB_TOKEN."
           fi
 
-      - run: yarn install
+      - run: yarn install --no-immutable
+        env:
+          YARN_ENABLE_HARDENED_MODE: "0"
       - run: yarn prepare
 
       - name: Run Smart TODO Action


### PR DESCRIPTION
Fixes failures in `Bump Package Version` and `Smart TODO Tracker` caused by Yarn hardened/immutable lockfile checks on pull_request closed runs.

Changes:
- set `YARN_ENABLE_HARDENED_MODE: "0"`
- use `yarn install --no-immutable` in post-merge workflows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes post-merge CI by disabling Yarn hardened mode and using non-immutable installs. Prevents failures in the Bump Package Version and Smart TODO Tracker workflows on pull_request closed.

- **Bug Fixes**
  - Set `YARN_ENABLE_HARDENED_MODE: "0"` and use `yarn install --no-immutable` in `bump_version.yml` and `todo.yml`.
  - Allows installs to proceed even if the lockfile changes after merge.

<sup>Written for commit 6ec975a87f40e5280b6b0f85865e23506fba7224. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

