### PR TITLE
fix(ci): make post-merge automations compatible with protected main

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout repository
@@ -34,7 +35,7 @@ jobs:
       - name: Bump version
         run: yarn bump-version
 
-      - name: Commit and push changes
+      - name: Commit and open PR for version bump
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -44,14 +45,10 @@ jobs:
             if git diff --cached --quiet; then
               echo "No version change."
             else
-              git commit -m "chore(release): bump version [skip ci]"
-              git push
               VERSION=$(node -p "require('./package.json').version")
-              git tag "v${VERSION}"
-              git push origin "v${VERSION}"
-              if gh release view "v${VERSION}" >/dev/null 2>&1; then
-                echo "Release v${VERSION} already exists."
-              else
-                gh release create "v${VERSION}" --title "v${VERSION}" --generate-notes
-              fi
+              BRANCH="chore/release-bump-v${VERSION}-${GITHUB_RUN_ID}"
+              git checkout -b "${BRANCH}"
+              git commit -m "chore(release): bump version to v${VERSION} [skip ci]"
+              git push origin "${BRANCH}"
+              gh pr create --base main --head "${BRANCH}" --title "chore(release): bump version to v${VERSION}" --body "Automated version bump generated after merge to main."
             fi

--- a/.github/workflows/todo.yml
+++ b/.github/workflows/todo.yml
@@ -48,6 +48,7 @@ jobs:
     permissions:
       contents: write
       issues: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v6
@@ -91,18 +92,20 @@ jobs:
       - name: Generate Changelog from TODOs
         run: yarn changelog
 
-      - name: Commit TODO report and CHANGELOG
+      - name: Commit TODO report and open PR
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          TARGET_BRANCH="${GITHUB_REF_NAME}"
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add TODO_REPORT.md CHANGELOG.md
-          git add .
           if git diff --cached --quiet; then
             echo "No changes to commit."
           else
+            BRANCH="chore/todo-report-${GITHUB_RUN_ID}"
+            git checkout -b "${BRANCH}"
             git commit -m "chore(report): update TODO report and changelog [skip ci]"
+            git push origin "${BRANCH}"
+            gh pr create --base main --head "${BRANCH}" --title "chore(report): update TODO report and changelog" --body "Automated TODO report and changelog update generated after merge to main."
           fi
-          git pull --rebase origin "${TARGET_BRANCH}"
-          git push origin "HEAD:${TARGET_BRANCH}"
   


### PR DESCRIPTION
Replaces direct pushes to protected main in post-merge workflows with branch + PR automation.\n\n- Bump Package Version: commit to generated branch and open PR to main\n- Smart TODO Tracker: commit report/changelog to generated branch and open PR to main\n- add pull-requests: write permissions where needed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch post-merge automations to a PR-based flow to work with a protected `main`. Version bumps and TODO/changelog updates now create branches and open PRs instead of pushing directly.

- **Bug Fixes**
  - Version bump: commit to `chore/release-bump-v{version}-{run_id}` and open PR to `main`.
  - TODO/changelog: commit to `chore/todo-report-{run_id}` and open PR to `main`.
  - CI: add `pull-requests: write` permissions to affected jobs.

<sup>Written for commit b3bd588cb32babb056a97d30dc959fd7ad350956. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

