### PR TITLE
fix(ci): use PAT for workflow-created PRs

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -35,9 +35,15 @@ jobs:
       - name: Bump version
         run: yarn bump-version
 
+      - name: Resolve PR token strategy
+        run: |
+          if [ -z "${{ secrets.PERSONAL_ACCESS_TOKEN }}" ]; then
+            echo "::warning::PERSONAL_ACCESS_TOKEN is not set. PR creation may fail if GitHub Actions PR creation is disabled."
+          fi
+
       - name: Commit and open PR for version bump
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN != '' && secrets.PERSONAL_ACCESS_TOKEN || github.token }}
         run: |
             git config --global user.name "github-actions[bot]"
             git config --global user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/todo.yml
+++ b/.github/workflows/todo.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Commit TODO report and open PR
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN != '' && secrets.PERSONAL_ACCESS_TOKEN || github.token }}
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
Ensure post-merge automation workflows can create PRs when GitHub Actions PR creation is disabled for GITHUB_TOKEN.\n\n- use PERSONAL_ACCESS_TOKEN for gh pr create when available\n- retain fallback to github.token\n- add warning when PAT is missing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer a personal access token for workflow-created PRs, with fallback to `GITHUB_TOKEN`, so post-merge automations can open PRs even when Actions-created PRs are blocked. Updated `bump_version.yml` and `todo.yml` and added a warning when `PERSONAL_ACCESS_TOKEN` is missing.

- **Migration**
  - Create a PAT with repo access and add it as the `PERSONAL_ACCESS_TOKEN` repository secret.
  - If not set, workflows will fall back to `GITHUB_TOKEN` (PR creation may fail per org policy).

<sup>Written for commit e2578bffbedc405d41447bd78bbe8eb6aa0d4064. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

