### PR TITLE
chore(release): bump version to v1.0.36

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-todo-action",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "description": "GitHub Action inteligente para transformar TODOs em issues e tarefas rastreáveis.",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Automated version bump generated after merge to main.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `smart-todo-action` version from 1.0.35 to 1.0.36 to publish a patch release. No code changes.

<sup>Written for commit b137cea7b11828650989c53a734b0cb5cdca5dba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

