### PR TITLE
fix(ci): enforce develop-only automation branch flow

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -47,14 +47,16 @@ jobs:
         run: |
             git config --global user.name "github-actions[bot]"
             git config --global user.email "github-actions[bot]@users.noreply.github.com"
+            git fetch origin develop
+            git checkout -b "chore/release-bump-${GITHUB_RUN_ID}" origin/develop
+            yarn bump-version
             git add package.json
             if git diff --cached --quiet; then
               echo "No version change."
             else
               VERSION=$(node -p "require('./package.json').version")
-              BRANCH="chore/release-bump-v${VERSION}-${GITHUB_RUN_ID}"
-              git checkout -b "${BRANCH}"
+              BRANCH=$(git branch --show-current)
               git commit -m "chore(release): bump version to v${VERSION} [skip ci]"
               git push origin "${BRANCH}"
-              gh pr create --base main --head "${BRANCH}" --title "chore(release): bump version to v${VERSION}" --body "Automated version bump generated after merge to main."
+              gh pr create --base develop --head "${BRANCH}" --title "chore(release): bump version to v${VERSION}" --body "Automated version bump generated after merge to main."
             fi

--- a/.github/workflows/todo.yml
+++ b/.github/workflows/todo.yml
@@ -98,14 +98,19 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          cp TODO_REPORT.md /tmp/TODO_REPORT.md
+          cp CHANGELOG.md /tmp/CHANGELOG.md
+          git fetch origin develop
+          BRANCH="chore/todo-report-${GITHUB_RUN_ID}"
+          git checkout -b "${BRANCH}" origin/develop
+          cp /tmp/TODO_REPORT.md TODO_REPORT.md
+          cp /tmp/CHANGELOG.md CHANGELOG.md
           git add TODO_REPORT.md CHANGELOG.md
           if git diff --cached --quiet; then
             echo "No changes to commit."
           else
-            BRANCH="chore/todo-report-${GITHUB_RUN_ID}"
-            git checkout -b "${BRANCH}"
             git commit -m "chore(report): update TODO report and changelog [skip ci]"
             git push origin "${BRANCH}"
-            gh pr create --base main --head "${BRANCH}" --title "chore(report): update TODO report and changelog" --body "Automated TODO report and changelog update generated after merge to main."
+            gh pr create --base develop --head "${BRANCH}" --title "chore(report): update TODO report and changelog" --body "Automated TODO report and changelog update generated after merge to main."
           fi
   


### PR DESCRIPTION
Align automation with branch policy:\n- no workflow-created PRs targeting main\n- automation branches/PRs now target develop only\n- preserve develop -> main as the only integration flow

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces CI automation to target the `develop` branch only. Version bump and TODO report workflows now create branches from `origin/develop` and open PRs against `develop`, preserving the develop → main flow.

- **Refactors**
  - Create automation branches from `origin/develop`; PRs now target `develop` in both workflows.
  - Bump workflow uses `yarn bump-version` on `chore/release-bump-${GITHUB_RUN_ID}`; TODO workflow preserves `TODO_REPORT.md` and `CHANGELOG.md` across checkout.

<sup>Written for commit 6f5507766f6ca957941bb2148ea98d6921f4eb6e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

