### PR TITLE
chore(release): bump version to v1.0.37

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-todo-action",
-  "version": "1.0.35",
+  "version": "1.0.37",
   "description": "GitHub Action inteligente para transformar TODOs em issues e tarefas rastreáveis.",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Automated version bump generated after merge to main.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped `smart-todo-action` version to v1.0.37 for the next release; no code changes.

<sup>Written for commit 073d39a17e728549d9994ee9679b7c7bc3f9eb2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

