### PR TITLE
chore: sync package description and add manual release workflow

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,0 +1,55 @@
+name: Publish Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Ensure workflow runs from main
+        run: |
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "::error::Run this workflow from the main branch."
+            exit 1
+          fi
+
+      - name: Resolve release tag from package version
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="v${VERSION}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "::notice::Preparing release for ${TAG}"
+
+      - name: Create tag when missing
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          if git ls-remote --tags origin "refs/tags/${TAG}" | grep -q "refs/tags/${TAG}$"; then
+            echo "::notice::Tag ${TAG} already exists."
+          else
+            git config --global user.name "github-actions[bot]"
+            git config --global user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "${TAG}"
+            git push origin "${TAG}"
+          fi
+
+      - name: Create GitHub release when missing
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            echo "::notice::Release ${TAG} already exists."
+          else
+            gh release create "${TAG}" --title "${TAG}" --generate-notes
+          fi

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "smart-todo-action",
   "version": "1.0.37",
-  "description": "GitHub Action inteligente para transformar TODOs em issues e tarefas rastreáveis.",
+  "description": "A  GitHub Action that scans your codebase for inline TODOs, FIXMEs, and BUG comments, and automatically creates GitHub Issues — with support for labels, metadata parsing, and semantic enrichment.",
   "main": "dist/index.js",
   "bin": {
     "todo-action": "dist/main.js"


### PR DESCRIPTION
## Summary
- sync `package.json` description with current repo description
- add manual `Publish Release` workflow (`workflow_dispatch`) that tags from `package.json` version and creates a GitHub Release

## Notes
- no workflow-created PRs
- release publishing is now manual and explicit from `main`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the `package.json` description with the repo. Adds a manual `Publish Release` workflow that tags from the package version and creates a GitHub Release.

- **New Features**
  - New GitHub Actions workflow `Publish Release` (manual `workflow_dispatch`) restricted to `main`.
  - Reads version from `package.json`, creates tag `v<version>` if missing, and creates a Release with generated notes.

- **Migration**
  - Releases are now manual from `main`; no workflow-created PRs.
  - To publish, run the workflow on `main`.

<sup>Written for commit 4f178cd07a99f0dd4ad57997875470b095ec1f4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

