### PR TITLE
docs: add branch model migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,37 @@ yarn check-version
 - Releases are published manually using the **Publish Release** workflow.
 - Run the workflow from the `main` branch to create the `v<package.json version>` tag and GitHub release.
 
+## 🌿 Branch Model Migration Guide
+
+Use this model when migrating from a single-branch flow to the current
+`develop` + `main` strategy.
+
+1. `develop` is the integration branch.
+2. `main` is the stable branch for releases only.
+3. Create feature/fix branches from `develop`.
+4. Open pull requests into `develop` and run validation there.
+5. Promote `develop` to `main` with a single PR when the milestone is ready.
+6. Trigger `Publish Release` manually from `main` after merge.
+
+### CI and workflow expectations
+
+- Test workflow runs on pull requests targeting both `develop` and `main`.
+- Post-merge automation (`todo.yml`, `bump_version.yml`) runs on `push` to `main`.
+- No workflow should auto-create PRs to `main`.
+
+### Protection recommendations
+
+- Protect both `develop` and `main` with required status checks.
+- Keep admin bypass enabled for emergency operations only.
+
+### Rollback approach
+
+If a `develop -> main` promotion causes problems:
+
+1. Revert the merge commit in `main`.
+2. Apply fixes in a new branch from `develop`.
+3. Merge back into `develop`, re-validate, and promote again.
+
 ## 📜 Citation
 
 If you use **smart-todo-action**, please cite it using the metadata in [CITATION.cff](CITATION.cff). This file contains the DOI and author information for reference managers.


### PR DESCRIPTION
Closes #306\n\n## Summary\n- add explicit migration steps for develop + main branch model\n- document CI/workflow behavior for test runs and post-merge automation\n- add branch protection recommendations and rollback procedure\n\nNo auto-merge performed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a README migration guide for moving to the `develop` + `main` branch model, covering clear steps, CI/workflow behavior, branch protection, and a safe rollback path. Clarifies how to validate on `develop`, promote to `main`, and trigger releases.

<sup>Written for commit b34345c4cf53c4800a9be230e317e8219c6cf214. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

