### PR TITLE
feat: support custom todo-keywords input

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ For citation information, see [CITATION.cff](CITATION.cff).
 - ✅ Creates labels on the fly if they don't exist
 - ✅ Supports custom label colors and descriptions via JSON config
 - ✅ Custom templates for issue titles and bodies
+- ✅ Supports custom TODO keywords via `todo-keywords` input
 - ✅ LLM-powered issue title and body generation
 - ✅ Automatic retry logic for OpenAI API calls
 - ✅ Supports multiple LLM providers: OpenAI or Gemini
@@ -60,6 +61,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           limit: 5
+          todo-keywords: NOTE,PERF
           llm: true
           llm-provider: openai # or 'gemini'
 ```

--- a/action.yml
+++ b/action.yml
@@ -84,6 +84,11 @@ inputs:
     description: Maximum number of issues to create
     default: '5'
 
+  todo-keywords:
+    required: false
+    description: Optional comma-separated extra TODO tags (e.g., NOTE,PERF)
+    default: ''
+
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/src/ActionMain.ts
+++ b/src/ActionMain.ts
@@ -2,14 +2,15 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
 import fs from 'fs';
-import { extractTodosFromDir } from './parser/extractTodosFromDir';
-import { extractTodosWithStructuredTagsFromDir } from './parser/extractTodosWithStructuredTagsFromDir'; // 👈 novo
+import { extractTodosFromDirWithKeywords } from './parser/extractTodosFromDir';
+import { extractTodosWithStructuredTagsFromDirWithKeywords } from './parser/extractTodosWithStructuredTagsFromDir';
 import { TodoItem } from './parser/types';
 import { getExistingIssueTitles, createIssueIfNeeded } from './core/issueManager';
 import { generateMarkdownReport, warnOverdueTodos } from './core/report';
 import { loadLabelConfig } from './core/labelManager';
 import { limitTodos, todoKey } from './core/todoUtils';
 import { generateChangelogFromTodos } from './core/changelog';
+import { parseTodoKeywordsInput } from './parser/todoKeywords';
 
 async function run(): Promise<void> {
   try {
@@ -43,10 +44,11 @@ async function run(): Promise<void> {
     }
 
     const warnOverdue = core.getInput('warn-overdue') === 'true';
+    const customKeywords = parseTodoKeywordsInput(core.getInput('todo-keywords') || '');
 
     const todos: TodoItem[] = useStructured
-      ? extractTodosWithStructuredTagsFromDir(workspace)
-      : extractTodosFromDir(workspace);
+      ? extractTodosWithStructuredTagsFromDirWithKeywords(workspace, customKeywords)
+      : extractTodosFromDirWithKeywords(workspace, customKeywords);
     const octokit = github.getOctokit(token);
     const { owner, repo } = github.context.repo;
 

--- a/src/parser/extractTodos.ts
+++ b/src/parser/extractTodos.ts
@@ -2,14 +2,13 @@ import fs from 'fs';
 import path from 'path';
 import { TodoItem } from './types';
 import { normalizeTag } from '../utils/isTextFile';
+import { buildTodoTagRegex } from './todoKeywords';
 
 const COMMENT_PATTERNS = [
   { ext: ['.ts', '.js', '.java', '.go', '.c', '.cpp', '.cs', '.rs', '.php', '.h', '.hpp'], pattern: /^\s*\/\/\s*(.*)$/ },
   { ext: ['.py', '.sh', '.rb', '.yaml', '.yml'], pattern: /^\s*#\s*(.*)$/ },
   { ext: ['.html', '.xml'], pattern: /<!--\s*(.*?)\s*-->/ }
 ];
-
-const TAG_REGEX = /^\s*(TODO|FIXME|BUG|HACK)(\([^)]*\))?:?\s*(.*)$/i;
 
 function extractMetadata(str: string): Record<string, string> {
   const meta: Record<string, string> = {};
@@ -24,10 +23,11 @@ function extractMetadata(str: string): Record<string, string> {
   return meta;
 }
 
-export function extractTodosFromFile(filePath: string): TodoItem[] {
+export function extractTodosFromFile(filePath: string, customKeywords: string[] = []): TodoItem[] {
   const ext = path.extname(filePath);
   const pattern = COMMENT_PATTERNS.find(p => p.ext.includes(ext));
   if (!pattern) return [];
+  const tagRegex = buildTodoTagRegex(customKeywords);
 
   const lines = fs.readFileSync(filePath, 'utf-8').split('\n');
   const todos: TodoItem[] = [];
@@ -36,11 +36,11 @@ export function extractTodosFromFile(filePath: string): TodoItem[] {
     const commentMatch = line.match(pattern.pattern);
     if (commentMatch) {
       const comment = commentMatch[1];
-      const tagMatch = comment.match(TAG_REGEX);
+      const tagMatch = comment.match(tagRegex);
       if (tagMatch) {
         const [_, rawTag, metaRaw, text] = tagMatch;
         const metadata = metaRaw ? extractMetadata(metaRaw) : undefined;
-        const tag = normalizeTag(rawTag) ?? rawTag;
+        const tag = normalizeTag(rawTag) ?? rawTag.toUpperCase();
         todos.push({
           file: filePath,
           line: idx + 1,

--- a/src/parser/extractTodosFromContent.ts
+++ b/src/parser/extractTodosFromContent.ts
@@ -2,14 +2,13 @@
 
 import { TodoItem } from './types';
 import { normalizeTag } from '../utils/isTextFile';
+import { buildTodoTagRegex } from './todoKeywords';
 
 const COMMENT_PATTERNS = [
   { ext: ['.ts', '.js', '.java', '.go', '.c', '.cpp', '.cs', '.rs', '.php', '.h', '.hpp'], pattern: /^\s*\/\/\s*(.*)$/ },
   { ext: ['.py', '.sh', '.rb', '.yaml', '.yml'], pattern: /^\s*#\s*(.*)$/ },
   { ext: ['.html', '.xml'], pattern: /<!--\s*(.*?)\s*-->/ }
 ];
-
-const TAG_REGEX = /^\s*(TODO|FIXME|BUG|HACK|À FAIRE|À CORRIGER|PROBLÈME|ZU TUN|ZU BEHEBEN|FEHLER)(\([^)]*\))?:?\s*(.*)$/i;
 
 function extractMetadata(str: string): Record<string, string> {
   const meta: Record<string, string> = {};
@@ -24,9 +23,10 @@ function extractMetadata(str: string): Record<string, string> {
   return meta;
 }
 
-export function extractTodosFromString(content: string, ext: string): TodoItem[] {
+export function extractTodosFromString(content: string, ext: string, customKeywords: string[] = []): TodoItem[] {
   const pattern = COMMENT_PATTERNS.find(p => p.ext.includes(ext));
   if (!pattern) return [];
+  const tagRegex = buildTodoTagRegex(customKeywords);
 
   const lines = content.split('\n');
   const todos: TodoItem[] = [];
@@ -35,11 +35,11 @@ export function extractTodosFromString(content: string, ext: string): TodoItem[]
     const commentMatch = line.match(pattern.pattern);
     if (commentMatch) {
       const comment = commentMatch[1];
-      const tagMatch = comment.match(TAG_REGEX);
+      const tagMatch = comment.match(tagRegex);
       if (tagMatch) {
         const [_, rawTag, metaRaw, text] = tagMatch;
         const metadata = metaRaw ? extractMetadata(metaRaw) : undefined;
-        const tag = normalizeTag(rawTag) ?? rawTag;
+        const tag = normalizeTag(rawTag) ?? rawTag.toUpperCase();
         todos.push({
           file: `inline${ext}`,
           line: idx + 1,

--- a/src/parser/extractTodosFromDir.ts
+++ b/src/parser/extractTodosFromDir.ts
@@ -7,6 +7,10 @@ const SUPPORTED_EXTENSIONS = ['.ts', '.js', '.py', '.go', '.java', '.rb', '.sh',
 const IGNORED_DIRS = ['node_modules', 'dist', 'coverage'];
 
 export function extractTodosFromDir(dirPath: string): TodoItem[] {
+  return extractTodosFromDirWithKeywords(dirPath, []);
+}
+
+export function extractTodosFromDirWithKeywords(dirPath: string, customKeywords: string[] = []): TodoItem[] {
   const todos: TodoItem[] = [];
 
   function walk(currentPath: string) {
@@ -21,7 +25,7 @@ export function extractTodosFromDir(dirPath: string): TodoItem[] {
       } else if (entry.isFile()) {
         const ext = path.extname(entry.name);
         if (SUPPORTED_EXTENSIONS.includes(ext)) {
-          const fileTodos = extractTodosFromFile(fullPath);
+          const fileTodos = extractTodosFromFile(fullPath, customKeywords);
           todos.push(...fileTodos);
         }
       }

--- a/src/parser/extractTodosWithStructuredTags.ts
+++ b/src/parser/extractTodosWithStructuredTags.ts
@@ -4,10 +4,10 @@ import { extractTodosFromString } from './extractTodosFromContent';
 import { extractStructuredTags } from './extractStructuredTags';
 import fs from 'fs';
 
-export function extractTodosWithStructuredTags(filePath: string): TodoItem[] {
+export function extractTodosWithStructuredTags(filePath: string, customKeywords: string[] = []): TodoItem[] {
   const ext = filePath.slice(filePath.lastIndexOf('.'));
   const content = fs.readFileSync(filePath, 'utf8');
-  const todos = extractTodosFromString(content, ext);
+  const todos = extractTodosFromString(content, ext, customKeywords);
 
   return todos.map(todo => {
     const structured = extractStructuredTags(todo.text);

--- a/src/parser/extractTodosWithStructuredTagsFromDir.ts
+++ b/src/parser/extractTodosWithStructuredTagsFromDir.ts
@@ -9,6 +9,10 @@ const IGNORED_DIRS = ['node_modules', 'dist', 'coverage'];
 
 
 export function extractTodosWithStructuredTagsFromDir(dir: string): TodoItem[] {
+  return extractTodosWithStructuredTagsFromDirWithKeywords(dir, []);
+}
+
+export function extractTodosWithStructuredTagsFromDirWithKeywords(dir: string, customKeywords: string[] = []): TodoItem[] {
   const todos: TodoItem[] = [];
 
   function walk(currentPath: string) {
@@ -22,7 +26,7 @@ export function extractTodosWithStructuredTagsFromDir(dir: string): TodoItem[] {
       } else if (entry.isFile()) {
         if (isTextFile(fullPath)) {
           try {
-            const fileTodos = extractTodosWithStructuredTags(fullPath);
+            const fileTodos = extractTodosWithStructuredTags(fullPath, customKeywords);
             todos.push(...fileTodos);
           } catch {
             // opcional: log de ficheiros ignorados

--- a/src/parser/todoKeywords.ts
+++ b/src/parser/todoKeywords.ts
@@ -1,0 +1,43 @@
+const DEFAULT_TODO_KEYWORDS = [
+  'TODO',
+  'FIXME',
+  'BUG',
+  'HACK',
+  'À FAIRE',
+  'À CORRIGER',
+  'PROBLÈME',
+  'ZU TUN',
+  'ZU BEHEBEN',
+  'FEHLER'
+];
+
+const CUSTOM_KEYWORD_PATTERN = /^[A-Za-z][A-Za-z0-9_-]{0,31}$/;
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function parseTodoKeywordsInput(rawInput: string): string[] {
+  if (!rawInput.trim()) return [];
+
+  const values = rawInput
+    .split(',')
+    .map(token => token.trim())
+    .filter(Boolean);
+
+  const invalid = values.filter(token => !CUSTOM_KEYWORD_PATTERN.test(token));
+  if (invalid.length > 0) {
+    throw new Error(
+      `Invalid todo-keywords value(s): ${invalid.join(', ')}. Use comma-separated keywords matching [A-Za-z][A-Za-z0-9_-]{0,31}.`
+    );
+  }
+
+  return Array.from(new Set(values.map(token => token.toUpperCase())));
+}
+
+export function buildTodoTagRegex(customKeywords: string[] = []): RegExp {
+  const keywords = Array.from(new Set([...DEFAULT_TODO_KEYWORDS, ...customKeywords]));
+  const alternation = keywords.map(escapeRegex).join('|');
+  return new RegExp(`^\\s*(${alternation})(\\([^)]*\\))?:?\\s*(.*)$`, 'i');
+}
+

--- a/tests/extractTodosFromContent.test.ts
+++ b/tests/extractTodosFromContent.test.ts
@@ -43,4 +43,13 @@ describe('extractTodosFromString', () => {
     const todos = extractTodosFromString(content, '.js');
     expect(todos.length).toBe(0);
   });
+
+  it('extracts custom configured keywords', () => {
+    const content = `// NOTE: improve docs\n// PERF: reduce allocations`;
+    const todos = extractTodosFromString(content, '.js', ['NOTE', 'PERF']);
+
+    expect(todos.length).toBe(2);
+    expect(todos[0].tag).toBe('NOTE');
+    expect(todos[1].tag).toBe('PERF');
+  });
 });

--- a/tests/todoKeywords.test.ts
+++ b/tests/todoKeywords.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { parseTodoKeywordsInput } from '../src/parser/todoKeywords';
+
+describe('parseTodoKeywordsInput', () => {
+  it('parses and normalizes comma-separated keywords', () => {
+    const keywords = parseTodoKeywordsInput('note, PERF, note');
+    expect(keywords).toEqual(['NOTE', 'PERF']);
+  });
+
+  it('rejects invalid keywords', () => {
+    expect(() => parseTodoKeywordsInput('TODO, BAD VALUE')).toThrow(
+      'Invalid todo-keywords value(s): BAD VALUE'
+    );
+  });
+});
+


### PR DESCRIPTION
Closes #304\n\n## Summary\n- add new action input 	odo-keywords (comma-separated extra tags)\n- validate and normalize custom keywords (uppercase, deduplicated, strict pattern)\n- make parser tag matching dynamic for defaults + custom keywords\n- thread custom keywords through standard and structured extraction flows\n- add tests for custom extraction and keyword validation\n- document usage in README\n\n## Notes\n- No auto-merge performed.\n- Local test execution is currently blocked by workspace lockfile state (yarn requests lockfile refresh).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for custom TODO keywords via the `todo-keywords` action input so you can capture tags like NOTE or PERF. The parser now validates, normalizes, and matches these tags across both standard and structured extraction.

- **New Features**
  - New `todo-keywords` input (comma‑separated) to add extra tags.
  - Strict validation and normalization (uppercase, deduped, pattern: `[A-Za-z][A-Za-z0-9_-]{0,31}`).
  - Dynamic tag matching for defaults + custom keywords in all extraction flows.
  - Tests added and README updated.

- **Migration**
  - Optional; no changes needed if you don’t use custom tags.
  - To enable: set `todo-keywords: NOTE,PERF` in your workflow.
  - Invalid keywords cause the action to fail with a clear message.

<sup>Written for commit 83aaf2ee9a22b4b325e9280ab6f501b13acf8484. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

