### PR TITLE
feat: add dry-run mode for issue creation preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ For citation information, see [CITATION.cff](CITATION.cff).
 - ✅ Supports custom label colors and descriptions via JSON config
 - ✅ Custom templates for issue titles and bodies
 - ✅ Supports custom TODO keywords via `todo-keywords` input
+- ✅ Dry-run mode to preview results without creating issues
 - ✅ LLM-powered issue title and body generation
 - ✅ Automatic retry logic for OpenAI API calls
 - ✅ Supports multiple LLM providers: OpenAI or Gemini
@@ -61,6 +62,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           limit: 5
+          dry-run: true
           todo-keywords: NOTE,PERF
           llm: true
           llm-provider: openai # or 'gemini'
@@ -110,6 +112,7 @@ If a label like `priority:high` or `due:2025-06-01` doesn't exist, it will be au
 ## 📌 Notes
 
 - Max **5 issues** are created per run to avoid rate limiting (configurable via the `limit` input)
+- Set `dry-run: true` to generate logs and `TODO_REPORT.md` without creating/updating GitHub issues
 - **Duplicate detection** prevents reopening the same TODO multiple times
 - All labels are **auto-created with default colors** if missing
 - Provide a JSON file via `label-config` to override colors and descriptions

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,11 @@ inputs:
     description: Whether to generate a TODO markdown report
     default: 'false'
 
+  dry-run:
+    required: false
+    description: Preview mode; do not create or update GitHub issues
+    default: 'false'
+
   structured:
     required: false
     description: Use structured tag extraction with @assignee, #module, and key=value

--- a/src/ActionMain.ts
+++ b/src/ActionMain.ts
@@ -16,6 +16,7 @@ async function run(): Promise<void> {
   try {
     const token = core.getInput('repo-token', { required: true });
     const generateReport = core.getInput('report') === 'true';
+    const dryRun = core.getInput('dry-run') === 'true';
     const titleTemplatePath = core.getInput('issue-title-template');
     const bodyTemplatePath = core.getInput('issue-body-template');
     const labelConfigPath = core.getInput('label-config');
@@ -53,8 +54,13 @@ async function run(): Promise<void> {
     const { owner, repo } = github.context.repo;
 
     core.info(`🔍 Found ${todos.length} TODOs`);
+    if (dryRun) {
+      core.info('🧪 Dry-run mode enabled: no issue creation/update calls will be made.');
+    }
 
-    const existingTitles = await getExistingIssueTitles(octokit, owner, repo);
+    const existingTitles = dryRun
+      ? new Set<string>()
+      : await getExistingIssueTitles(octokit, owner, repo);
 
     const seenKeys = new Set<string>();
     const uniqueTodos = todos.filter(todo => {
@@ -72,19 +78,23 @@ async function run(): Promise<void> {
     const todosToCreate = limitTodos(uniqueTodos, issueLimit);
 
 
-    for (const todo of todosToCreate) {
-      await createIssueIfNeeded(
-        octokit,
-        owner,
-        repo,
-        todo,
-        existingTitles,
-        titleTemplatePath,
-        bodyTemplatePath
-      );
+    if (!dryRun) {
+      for (const todo of todosToCreate) {
+        await createIssueIfNeeded(
+          octokit,
+          owner,
+          repo,
+          todo,
+          existingTitles,
+          titleTemplatePath,
+          bodyTemplatePath
+        );
+      }
+    } else {
+      core.info(`🧪 Dry-run summary: ${todosToCreate.length} issue(s) would be processed.`);
     }
 
-    if (generateReport) {
+    if (generateReport || dryRun) {
       generateMarkdownReport(todos);
       core.info('📝 Generated TODO_REPORT.md');
 


### PR DESCRIPTION
Closes #299\n\n## Summary\n- add new action input dry-run (default alse)\n- when dry-run: true, skip issue creation/update flow entirely\n- still generate TODO report output and summary logs in dry-run mode\n- document dry-run behavior and usage in README\n\nNo auto-merge performed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `dry-run` mode to preview which issues would be created, without creating or updating GitHub issues. Reduces API calls while still producing logs and `TODO_REPORT.md` for review.

- **New Features**
  - Add `dry-run` input in `action.yml` (default `false`).
  - When `true`, skip fetching existing issue titles and all create/update calls; log how many issues would be processed.
  - Generate `TODO_REPORT.md` when `report: true` or in dry-run.
  - README updated with feature note and usage example.

<sup>Written for commit f93331ee3ec531584d9b9bbaf0180017f27493f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

