### PR TITLE
feat: add configurable ignore globs for TODO scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ For citation information, see [CITATION.cff](CITATION.cff).
 - ✅ Detects `TODO`, `FIXME`, `BUG`, and `HACK` comments
 - ✅ Supports many languages: `.ts`, `.js`, `.py`, `.go`, `.c`, `.cpp`, `.rs`, `.html`, `.yaml`, etc.
 - ✅ Skips common directories like `node_modules`, `dist`, and `coverage`
+- ✅ Supports custom ignore globs for scanner exclusions
 - ✅ Extracts metadata like `priority`, `due`, etc.
 - ✅ Parses structured tags (`@assignee`, `#module`, `key=value`)
 - ✅ Warns about overdue TODOs
@@ -62,6 +63,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           limit: 5
           todo-keywords: NOTE,PERF
+          ignore-globs: "**/fixtures/**,**/*.snap"
           llm: true
           llm-provider: openai # or 'gemini'
 ```
@@ -113,6 +115,7 @@ If a label like `priority:high` or `due:2025-06-01` doesn't exist, it will be au
 - **Duplicate detection** prevents reopening the same TODO multiple times
 - All labels are **auto-created with default colors** if missing
 - Provide a JSON file via `label-config` to override colors and descriptions
+- Use `ignore-globs` to exclude custom paths/files beyond default ignores
 
 ## 🗂️ Project Structure
 

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,11 @@ inputs:
     required: false
     description: Optional path to JSON file with custom label colors and descriptions
 
+  ignore-globs:
+    required: false
+    description: Optional comma-separated glob patterns to ignore while scanning files
+    default: ''
+
   llm:
     required: false
     description: Use LLM to generate issue titles and bodies

--- a/src/ActionMain.ts
+++ b/src/ActionMain.ts
@@ -11,6 +11,7 @@ import { loadLabelConfig } from './core/labelManager';
 import { limitTodos, todoKey } from './core/todoUtils';
 import { generateChangelogFromTodos } from './core/changelog';
 import { parseTodoKeywordsInput } from './parser/todoKeywords';
+import { parseIgnoreGlobsInput } from './parser/ignoreGlobs';
 
 async function run(): Promise<void> {
   try {
@@ -38,6 +39,7 @@ async function run(): Promise<void> {
     }
 
     const useStructured = core.getInput('structured') === 'true';
+    const ignoreGlobs = parseIgnoreGlobsInput(core.getInput('ignore-globs') || '');
 
     if (labelConfigPath) {
       loadLabelConfig(labelConfigPath);
@@ -47,8 +49,8 @@ async function run(): Promise<void> {
     const customKeywords = parseTodoKeywordsInput(core.getInput('todo-keywords') || '');
 
     const todos: TodoItem[] = useStructured
-      ? extractTodosWithStructuredTagsFromDirWithKeywords(workspace, customKeywords)
-      : extractTodosFromDirWithKeywords(workspace, customKeywords);
+      ? extractTodosWithStructuredTagsFromDirWithKeywords(workspace, customKeywords, ignoreGlobs)
+      : extractTodosFromDirWithKeywords(workspace, customKeywords, ignoreGlobs);
     const octokit = github.getOctokit(token);
     const { owner, repo } = github.context.repo;
 

--- a/src/parser/extractTodosFromDir.ts
+++ b/src/parser/extractTodosFromDir.ts
@@ -2,27 +2,34 @@ import fs from 'fs';
 import path from 'path';
 import { extractTodosFromFile } from './extractTodos';
 import { TodoItem } from './types';
+import { buildIgnoreMatchers, shouldIgnorePath } from './ignoreGlobs';
 
 const SUPPORTED_EXTENSIONS = ['.ts', '.js', '.py', '.go', '.java', '.rb', '.sh', '.c', '.cpp', '.cs', '.rs', '.php', '.h', '.hpp', '.html', '.xml', '.yaml', '.yml'];
-const IGNORED_DIRS = ['node_modules', 'dist', 'coverage'];
 
 export function extractTodosFromDir(dirPath: string): TodoItem[] {
-  return extractTodosFromDirWithKeywords(dirPath, []);
+  return extractTodosFromDirWithKeywords(dirPath, [], []);
 }
 
-export function extractTodosFromDirWithKeywords(dirPath: string, customKeywords: string[] = []): TodoItem[] {
+export function extractTodosFromDirWithKeywords(
+  dirPath: string,
+  customKeywords: string[] = [],
+  customIgnoreGlobs: string[] = []
+): TodoItem[] {
   const todos: TodoItem[] = [];
+  const ignoreMatchers = buildIgnoreMatchers(customIgnoreGlobs);
 
   function walk(currentPath: string) {
     const entries = fs.readdirSync(currentPath, { withFileTypes: true });
 
     for (const entry of entries) {
       const fullPath = path.join(currentPath, entry.name);
+      const relativePath = path.relative(dirPath, fullPath).replace(/\\/g, '/');
 
       if (entry.isDirectory()) {
-        if (IGNORED_DIRS.includes(entry.name)) continue;
+        if (shouldIgnorePath(relativePath, ignoreMatchers)) continue;
         walk(fullPath);
       } else if (entry.isFile()) {
+        if (shouldIgnorePath(relativePath, ignoreMatchers)) continue;
         const ext = path.extname(entry.name);
         if (SUPPORTED_EXTENSIONS.includes(ext)) {
           const fileTodos = extractTodosFromFile(fullPath, customKeywords);

--- a/src/parser/extractTodosFromDir.ts
+++ b/src/parser/extractTodosFromDir.ts
@@ -10,6 +10,10 @@ export function extractTodosFromDir(dirPath: string): TodoItem[] {
   return extractTodosFromDirWithKeywords(dirPath, [], []);
 }
 
+export function extractTodosFromDirWithIgnoreGlobs(dirPath: string, customIgnoreGlobs: string[] = []): TodoItem[] {
+  return extractTodosFromDirWithKeywords(dirPath, [], customIgnoreGlobs);
+}
+
 export function extractTodosFromDirWithKeywords(
   dirPath: string,
   customKeywords: string[] = [],

--- a/src/parser/extractTodosWithStructuredTagsFromDir.ts
+++ b/src/parser/extractTodosWithStructuredTagsFromDir.ts
@@ -4,26 +4,32 @@ import fs from 'fs';
 import { TodoItem } from './types';
 import { extractTodosWithStructuredTags } from './extractTodosWithStructuredTags';
 import { isTextFile } from '../utils/isTextFile';
-
-const IGNORED_DIRS = ['node_modules', 'dist', 'coverage'];
+import { buildIgnoreMatchers, shouldIgnorePath } from './ignoreGlobs';
 
 
 export function extractTodosWithStructuredTagsFromDir(dir: string): TodoItem[] {
-  return extractTodosWithStructuredTagsFromDirWithKeywords(dir, []);
+  return extractTodosWithStructuredTagsFromDirWithKeywords(dir, [], []);
 }
 
-export function extractTodosWithStructuredTagsFromDirWithKeywords(dir: string, customKeywords: string[] = []): TodoItem[] {
+export function extractTodosWithStructuredTagsFromDirWithKeywords(
+  dir: string,
+  customKeywords: string[] = [],
+  customIgnoreGlobs: string[] = []
+): TodoItem[] {
   const todos: TodoItem[] = [];
+  const ignoreMatchers = buildIgnoreMatchers(customIgnoreGlobs);
 
   function walk(currentPath: string) {
     const entries = fs.readdirSync(currentPath, { withFileTypes: true });
 
     for (const entry of entries) {
       const fullPath = path.join(currentPath, entry.name);
+      const relativePath = path.relative(dir, fullPath).replace(/\\/g, '/');
       if (entry.isDirectory()) {
-        if (IGNORED_DIRS.includes(entry.name)) continue;
+        if (shouldIgnorePath(relativePath, ignoreMatchers)) continue;
         walk(fullPath);
       } else if (entry.isFile()) {
+        if (shouldIgnorePath(relativePath, ignoreMatchers)) continue;
         if (isTextFile(fullPath)) {
           try {
             const fileTodos = extractTodosWithStructuredTags(fullPath, customKeywords);

--- a/src/parser/ignoreGlobs.ts
+++ b/src/parser/ignoreGlobs.ts
@@ -1,0 +1,66 @@
+const DEFAULT_IGNORED_GLOBS = [
+  '**/node_modules/**',
+  '**/dist/**',
+  '**/coverage/**'
+];
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+}
+
+function globToRegex(glob: string): RegExp {
+  const normalized = glob.replace(/\\/g, '/').replace(/^\.\/+/, '');
+  const hasLeadingAnyDir = normalized.startsWith('**/');
+  const source = hasLeadingAnyDir ? normalized.slice(3) : normalized;
+  let regex = '';
+
+  for (let i = 0; i < source.length; i += 1) {
+    const current = source[i];
+    const next = source[i + 1];
+
+    if (current === '*' && next === '*') {
+      regex += '.*';
+      i += 1;
+      continue;
+    }
+
+    if (current === '*') {
+      regex += '[^/]*';
+      continue;
+    }
+
+    if (current === '?') {
+      regex += '[^/]';
+      continue;
+    }
+
+    regex += escapeRegex(current);
+  }
+
+  const prefix = hasLeadingAnyDir ? '(?:.*/)?' : '';
+
+  if (!source.includes('/')) {
+    return new RegExp(`^(?:.*/)?${prefix}${regex}(?:/.*)?$`);
+  }
+
+  return new RegExp(`^${prefix}${regex}$`);
+}
+
+export function parseIgnoreGlobsInput(rawInput: string): string[] {
+  if (!rawInput.trim()) return [];
+  return rawInput
+    .split(',')
+    .map(token => token.trim())
+    .filter(Boolean)
+    .map(token => token.replace(/\\/g, '/'));
+}
+
+export function buildIgnoreMatchers(customIgnoreGlobs: string[] = []): RegExp[] {
+  const all = [...DEFAULT_IGNORED_GLOBS, ...customIgnoreGlobs];
+  return all.map(globToRegex);
+}
+
+export function shouldIgnorePath(relativePath: string, matchers: RegExp[]): boolean {
+  const normalized = relativePath.replace(/\\/g, '/').replace(/^\.\//, '');
+  return matchers.some(matcher => matcher.test(normalized) || matcher.test(`${normalized}/`));
+}

--- a/tests/extractTodosFromDir.test.ts
+++ b/tests/extractTodosFromDir.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { extractTodosFromDir } from '../src/parser/extractTodosFromDir';
+import { extractTodosFromDir, extractTodosFromDirWithIgnoreGlobs } from '../src/parser/extractTodosFromDir';
 
 describe('extractTodosFromDir', () => {
   const base = path.join(__dirname, 'fixtures');
@@ -30,5 +30,11 @@ describe('extractTodosFromDir', () => {
     const todos = extractTodosFromDir(base);
     const ignored = todos.find(t => t.text.includes('Should not be picked up'));
     expect(ignored).toBeUndefined();
+  });
+
+  it('should respect custom ignore globs', () => {
+    const todos = extractTodosFromDirWithIgnoreGlobs(base, ['**/nested/**']);
+    expect(todos.length).toBe(1);
+    expect(todos[0].text).toBe('Refactor this module');
   });
 });

--- a/tests/ignoreGlobs.test.ts
+++ b/tests/ignoreGlobs.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { buildIgnoreMatchers, parseIgnoreGlobsInput, shouldIgnorePath } from '../src/parser/ignoreGlobs';
+
+describe('ignoreGlobs', () => {
+  it('parses comma-separated ignore globs', () => {
+    expect(parseIgnoreGlobsInput('**/fixtures/**, **/*.snap')).toEqual(['**/fixtures/**', '**/*.snap']);
+  });
+
+  it('matches default ignored paths', () => {
+    const matchers = buildIgnoreMatchers([]);
+    expect(shouldIgnorePath('node_modules/pkg/index.js', matchers)).toBe(true);
+    expect(shouldIgnorePath('src/main.ts', matchers)).toBe(false);
+  });
+
+  it('matches custom ignored paths', () => {
+    const matchers = buildIgnoreMatchers(['**/fixtures/**']);
+    expect(shouldIgnorePath('tests/fixtures/one-file.ts', matchers)).toBe(true);
+    expect(shouldIgnorePath('tests/example.ts', matchers)).toBe(false);
+  });
+});
+


### PR DESCRIPTION
Closes #300\n\n## Summary\n- add new action input ignore-globs (comma-separated patterns)\n- apply ignore globs during recursive scan for both regular and structured extraction\n- preserve default ignores (
ode_modules, dist, coverage)\n- add unit tests for parser ignore matching and custom exclusion behavior\n- document ignore-globs usage in README\n\n## Notes\n- No auto-merge performed.\n- Local test run is currently blocked by workspace Yarn lockfile state and reports: This package doesn't seem to be present in your lockfile.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add configurable ignore globs to the TODO scanner so you can exclude custom files and folders while keeping default ignores. Works for both regular and structured scans and addresses #300.

- **New Features**
  - Adds `ignore-globs` input (comma-separated, e.g. `**/fixtures/**,**/*.snap`) to control exclusions.
  - Applies glob matching in both directory walkers; default ignores (`node_modules`, `dist`, `coverage`) remain.
  - Adds parsing/matching utilities and tests; updates README with usage.

- **Bug Fixes**
  - Restores exported `extractTodosFromDirWithIgnoreGlobs` and applies ignore rules to both directories and files.
  - Passes parsed globs from the action input through `ActionMain` to both scan paths.

<sup>Written for commit 075925fd5ce3efc4dbaec4f806497fe1f8a1f3b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

