### PR TITLE
feat: add configurable deduplication strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ For citation information, see [CITATION.cff](CITATION.cff).
 - ✅ Supports multiple LLM providers: OpenAI or Gemini
 - ✅ Command-line interface for local usage
 - ✅ Optional Jira synchronization
+- ✅ Configurable deduplication strategy (`title`, `normalized-text`, `hash`)
 
 ---
 
@@ -66,6 +67,7 @@ jobs:
           dry-run: true
           todo-keywords: NOTE,PERF
           ignore-globs: "**/fixtures/**,**/*.snap"
+          dedup-strategy: normalized-text
           llm: true
           llm-provider: openai # or 'gemini'
 ```
@@ -116,6 +118,7 @@ If a label like `priority:high` or `due:2025-06-01` doesn't exist, it will be au
 - Max **5 issues** are created per run to avoid rate limiting (configurable via the `limit` input)
 - Set `dry-run: true` to generate logs and `TODO_REPORT.md` without creating/updating GitHub issues
 - **Duplicate detection** prevents reopening the same TODO multiple times
+- Dedup strategy can be configured with `dedup-strategy`: `title` (default), `normalized-text`, or `hash`
 - All labels are **auto-created with default colors** if missing
 - Provide a JSON file via `label-config` to override colors and descriptions
 - Use `ignore-globs` to exclude custom paths/files beyond default ignores

--- a/action.yml
+++ b/action.yml
@@ -99,6 +99,11 @@ inputs:
     description: Optional comma-separated extra TODO tags (e.g., NOTE,PERF)
     default: ''
 
+  dedup-strategy:
+    required: false
+    description: Dedup mode for matching TODOs/issues (title, normalized-text, hash)
+    default: 'title'
+
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/src/ActionMain.ts
+++ b/src/ActionMain.ts
@@ -5,10 +5,10 @@ import fs from 'fs';
 import { extractTodosFromDirWithKeywords } from './parser/extractTodosFromDir';
 import { extractTodosWithStructuredTagsFromDirWithKeywords } from './parser/extractTodosWithStructuredTagsFromDir';
 import { TodoItem } from './parser/types';
-import { getExistingIssueTitles, createIssueIfNeeded } from './core/issueManager';
+import { getExistingIssueDedupKeys, createIssueIfNeeded } from './core/issueManager';
 import { generateMarkdownReport, warnOverdueTodos } from './core/report';
 import { loadLabelConfig } from './core/labelManager';
-import { limitTodos, todoKey } from './core/todoUtils';
+import { DedupStrategy, isDedupStrategy, limitTodos, todoKey } from './core/todoUtils';
 import { generateChangelogFromTodos } from './core/changelog';
 import { parseTodoKeywordsInput } from './parser/todoKeywords';
 import { parseIgnoreGlobsInput } from './parser/ignoreGlobs';
@@ -48,6 +48,11 @@ async function run(): Promise<void> {
 
     const warnOverdue = core.getInput('warn-overdue') === 'true';
     const customKeywords = parseTodoKeywordsInput(core.getInput('todo-keywords') || '');
+    const dedupInput = (core.getInput('dedup-strategy') || 'title').trim();
+    if (!isDedupStrategy(dedupInput)) {
+      throw new Error(`Invalid dedup-strategy: ${dedupInput}. Allowed values: title, normalized-text, hash.`);
+    }
+    const dedupStrategy: DedupStrategy = dedupInput;
 
     const todos: TodoItem[] = useStructured
       ? extractTodosWithStructuredTagsFromDirWithKeywords(workspace, customKeywords, ignoreGlobs)
@@ -60,13 +65,13 @@ async function run(): Promise<void> {
       core.info('🧪 Dry-run mode enabled: no issue creation/update calls will be made.');
     }
 
-    const existingTitles = dryRun
+    const existingDedupKeys = dryRun
       ? new Set<string>()
-      : await getExistingIssueTitles(octokit, owner, repo);
+      : await getExistingIssueDedupKeys(octokit, owner, repo, dedupStrategy);
 
     const seenKeys = new Set<string>();
     const uniqueTodos = todos.filter(todo => {
-      const key = todoKey(todo);
+      const key = todoKey(todo, dedupStrategy);
       if (seenKeys.has(key)) return false;
       seenKeys.add(key);
       return true;
@@ -87,7 +92,8 @@ async function run(): Promise<void> {
           owner,
           repo,
           todo,
-          existingTitles,
+          existingDedupKeys,
+          dedupStrategy,
           titleTemplatePath,
           bodyTemplatePath
         );

--- a/src/core/issueManager.ts
+++ b/src/core/issueManager.ts
@@ -5,11 +5,21 @@ import { LABELS_BY_TAG, labelsFromMetadata, ensureLabelExists, labelsFromTodo } 
 import { loadTemplate, applyTemplate } from '../templates/utils';
 import { generateIssueTitleAndBodyLLM } from './llm/generateIssueContent';
 import { createJiraIssue } from "../integrations/jira";
+import { DedupStrategy, dedupKeyFromTitle } from './todoUtils';
 
 export async function getExistingIssueTitles(
   octokit: ReturnType<typeof github.getOctokit>,
   owner: string,
   repo: string
+): Promise<Set<string>> {
+  return getExistingIssueDedupKeys(octokit, owner, repo, 'title');
+}
+
+export async function getExistingIssueDedupKeys(
+  octokit: ReturnType<typeof github.getOctokit>,
+  owner: string,
+  repo: string,
+  dedupStrategy: DedupStrategy
 ): Promise<Set<string>> {
   const existing = new Set<string>();
   const perPage = 100;
@@ -27,7 +37,7 @@ export async function getExistingIssueTitles(
 
     for (const issue of data) {
       if (!issue.pull_request) {
-        existing.add(issue.title);
+        existing.add(dedupKeyFromTitle(issue.title, dedupStrategy));
       }
     }
 
@@ -46,7 +56,8 @@ export async function createIssueIfNeeded(
   owner: string,
   repo: string,
   todo: TodoItem,
-  existingTitles: Set<string>,
+  existingDedupKeys: Set<string>,
+  dedupStrategy: DedupStrategy = 'title',
   titlePath?: string,
   bodyPath?: string
 ): Promise<void> {
@@ -76,7 +87,8 @@ export async function createIssueIfNeeded(
     body = applyTemplate(bodyTemplate, flattened);
   }
 
-  if (existingTitles.has(title)) {
+  const dedupKey = dedupKeyFromTitle(title, dedupStrategy);
+  if (existingDedupKeys.has(dedupKey)) {
     core.info(`🟡 Skipping duplicate issue: ${title}`);
     return;
   }

--- a/src/core/todoUtils.ts
+++ b/src/core/todoUtils.ts
@@ -1,4 +1,7 @@
 import { TodoItem } from '../parser/types';
+import crypto from 'crypto';
+
+export type DedupStrategy = 'title' | 'normalized-text' | 'hash';
 
 export function buildIssueTitle(todo: TodoItem): string {
   return `[${todo.tag}] ${todo.text}`;
@@ -12,6 +15,31 @@ export function limitTodos(todos: TodoItem[], max = 5): TodoItem[] {
   return todos.filter(isValidTodo).slice(0, max);
 }
 
-export function todoKey(todo: TodoItem): string {
-  return `[${todo.tag}] ${todo.text}`;
+export function normalizeForDedup(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function isDedupStrategy(value: string): value is DedupStrategy {
+  return value === 'title' || value === 'normalized-text' || value === 'hash';
+}
+
+export function dedupKeyFromTitle(title: string, strategy: DedupStrategy): string {
+  if (strategy === 'title') return title;
+
+  const normalized = normalizeForDedup(title);
+  if (strategy === 'normalized-text') return normalized;
+
+  return crypto.createHash('sha256').update(normalized).digest('hex');
+}
+
+export function dedupKeyFromTodo(todo: TodoItem, strategy: DedupStrategy): string {
+  const title = buildIssueTitle(todo);
+  return dedupKeyFromTitle(title, strategy);
+}
+
+export function todoKey(todo: TodoItem, strategy: DedupStrategy = 'title'): string {
+  return dedupKeyFromTodo(todo, strategy);
 }

--- a/tests/issueManager.test.ts
+++ b/tests/issueManager.test.ts
@@ -77,4 +77,12 @@ describe('createIssueIfNeeded', () => {
       labels: ['enhancement', 'priority:high', 'refactor'] // ✅ agora incluindo semantic label
     });
   });
+
+  it('should skip duplicate issues with normalized-text strategy', async () => {
+    const existingKeys: Set<string> = new Set(['[todo] refactor component']);
+
+    await createIssueIfNeeded(octokit, owner, repo, todo, existingKeys, 'normalized-text');
+
+    expect(octokit.rest.issues.create).not.toHaveBeenCalled();
+  });
 });

--- a/tests/todoUtils.test.ts
+++ b/tests/todoUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { limitTodos, todoKey } from '../src/core/todoUtils';
+import { dedupKeyFromTitle, limitTodos, todoKey } from '../src/core/todoUtils';
 import { TodoItem } from '../src/parser/types';
 
 
@@ -40,6 +40,18 @@ describe('todoKey', () => {
 
     expect(result.length).toBe(2);
     expect(result.map(t => t.text)).toEqual(['duplicate task', 'unique task']);
+  });
+
+  it('supports normalized-text dedup strategy', () => {
+    const a: TodoItem = { tag: 'TODO', text: 'Refactor   Component', file: 'a.ts', line: 1 };
+    const b: TodoItem = { tag: 'TODO', text: 'refactor component', file: 'b.ts', line: 2 };
+
+    expect(todoKey(a, 'normalized-text')).toBe(todoKey(b, 'normalized-text'));
+  });
+
+  it('supports hash dedup strategy', () => {
+    const key = dedupKeyFromTitle('[TODO] Refactor component', 'hash');
+    expect(key).toMatch(/^[a-f0-9]{64}$/);
   });
 });
 


### PR DESCRIPTION
Closes #305\n\n## Summary\n- add new input dedup-strategy with supported values: 	itle (default), 
ormalized-text, hash\n- add shared dedup key generation in 	odoUtils\n- apply strategy to pre-create TODO dedup and existing-open-issue matching\n- preserve backward compatibility by keeping default 	itle behavior\n- add unit tests for normalized/hash strategy behavior\n- document usage in README\n\nNo auto-merge performed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a configurable deduplication strategy for TODO-to-issue and existing-issue matching to reduce duplicates. Defaults to `title`; supports `normalized-text` and `hash` per #305.

- **New Features**
  - New `dedup-strategy` input: `title` (default), `normalized-text`, `hash`
  - Applied to in-run TODO dedup and matching against open issues
  - Centralized key generation with strict input validation and clear errors; updated `action.yml`, README, and tests

- **Migration**
  - No action needed; default stays `title`
  - To enable smarter matching, set `dedup-strategy: normalized-text` (or `hash`) in your workflow

<sup>Written for commit be485f76e9eefbd610ae5c6bb766e6b8475a2f31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

