### PR TITLE
feat(release): add deterministic branch-aware release notes

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -43,6 +43,14 @@ jobs:
             git push origin "${TAG}"
           fi
 
+      - name: Generate branch-aware release notes
+        run: node scripts/generateReleaseNotes.js
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+          RELEASE_BRANCH: ${{ github.ref_name }}
+          RELEASE_TO_REF: HEAD
+          RELEASE_NOTES_PATH: RELEASE_NOTES.md
+
       - name: Create GitHub release when missing
         env:
           GH_TOKEN: ${{ github.token }}
@@ -51,5 +59,5 @@ jobs:
           if gh release view "${TAG}" >/dev/null 2>&1; then
             echo "::notice::Release ${TAG} already exists."
           else
-            gh release create "${TAG}" --title "${TAG}" --generate-notes
+            gh release create "${TAG}" --title "${TAG}" --notes-file RELEASE_NOTES.md
           fi

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ yarn check-version
 - Main integration flow: `develop -> main` (via pull request).
 - Releases are published manually using the **Publish Release** workflow.
 - Run the workflow from the `main` branch to create the `v<package.json version>` tag and GitHub release.
+- Release notes are generated with deterministic sections: `Highlights`, `Fixes`, `Dependencies`, and `Breaking Changes` (empty sections are omitted).
 
 ## 🌿 Branch Model Migration Guide
 

--- a/scripts/generateReleaseNotes.js
+++ b/scripts/generateReleaseNotes.js
@@ -1,0 +1,51 @@
+const fs = require('node:fs');
+const { execSync } = require('node:child_process');
+const { buildReleaseNotes } = require('./releaseNotes');
+
+function readEnv(name, fallback = '') {
+  const value = process.env[name];
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+}
+
+function listTags() {
+  const output = execSync('git tag --list "v*" --sort=-creatordate', { encoding: 'utf8' }).trim();
+  return output ? output.split(/\r?\n/).map((x) => x.trim()).filter(Boolean) : [];
+}
+
+function collectCommits(fromRef, toRef) {
+  const range = fromRef ? `${fromRef}..${toRef}` : toRef;
+  const output = execSync(`git log --format=%s%x00%b%x1e ${range}`, { encoding: 'utf8' });
+
+  return output
+    .split('\x1e')
+    .map((record) => record.trim())
+    .filter(Boolean)
+    .map((record) => {
+      const [subject = '', body = ''] = record.split('\x00');
+      return { subject: subject.trim(), body: body.trim() };
+    });
+}
+
+function main() {
+  const tag = readEnv('RELEASE_TAG', 'v0.0.0');
+  const branch = readEnv('RELEASE_BRANCH', 'unknown');
+  const toRef = readEnv('RELEASE_TO_REF', 'HEAD');
+  const notesPath = readEnv('RELEASE_NOTES_PATH', 'RELEASE_NOTES.md');
+
+  const allTags = listTags();
+  const fromRef = allTags.find((t) => t !== tag) || '';
+  const commits = collectCommits(fromRef, toRef);
+
+  const notes = buildReleaseNotes({
+    branch,
+    tag,
+    fromRef,
+    toRef,
+    commits,
+  });
+
+  fs.writeFileSync(notesPath, notes, 'utf8');
+  console.log(`Generated ${notesPath} with ${commits.length} commit(s).`);
+}
+
+main();

--- a/scripts/releaseNotes.js
+++ b/scripts/releaseNotes.js
@@ -1,0 +1,65 @@
+function normalizeLine(value) {
+  return String(value || '').trim();
+}
+
+function classifyCommit(subject, body) {
+  const s = normalizeLine(subject);
+  const b = normalizeLine(body);
+  const lower = s.toLowerCase();
+  const typeMatch = s.match(/^([a-z]+)(\([^)]+\))?(!)?:\s+/i);
+  const type = typeMatch ? typeMatch[1].toLowerCase() : '';
+  const scope = typeMatch && typeMatch[2] ? typeMatch[2].toLowerCase() : '';
+  const hasBang = Boolean(typeMatch && typeMatch[3]);
+
+  if (hasBang || /breaking change/i.test(b)) return 'breaking';
+  if (scope.includes('deps') || /dependabot|\bdeps?\b|\bdependency\b/.test(lower)) return 'dependencies';
+  if (type === 'fix') return 'fixes';
+  return 'highlights';
+}
+
+function buildReleaseNotes({ branch, tag, fromRef, toRef, commits }) {
+  const sections = {
+    highlights: new Set(),
+    fixes: new Set(),
+    dependencies: new Set(),
+    breaking: new Set(),
+  };
+
+  for (const commit of commits) {
+    const subject = normalizeLine(commit.subject);
+    if (!subject) continue;
+    const category = classifyCommit(subject, commit.body);
+    sections[category].add(subject);
+  }
+
+  const out = [];
+  out.push(`# ${tag} Release Notes`);
+  out.push('');
+  out.push(`- Branch: \`${branch}\``);
+  if (fromRef && toRef) {
+    out.push(`- Range: \`${fromRef}..${toRef}\``);
+  }
+
+  const orderedSections = [
+    ['highlights', 'Highlights'],
+    ['fixes', 'Fixes'],
+    ['dependencies', 'Dependencies'],
+    ['breaking', 'Breaking Changes'],
+  ];
+
+  for (const [key, title] of orderedSections) {
+    const entries = Array.from(sections[key]).sort((a, b) => a.localeCompare(b));
+    if (entries.length === 0) continue;
+    out.push('');
+    out.push(`## ${title}`);
+    for (const line of entries) {
+      out.push(`- ${line}`);
+    }
+  }
+
+  return `${out.join('\n')}\n`;
+}
+
+module.exports = {
+  buildReleaseNotes,
+};

--- a/tests/releaseNotes.test.ts
+++ b/tests/releaseNotes.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { buildReleaseNotes } = require('../scripts/releaseNotes');
+
+describe('buildReleaseNotes', () => {
+  it('builds deterministic sections and omits empty ones', () => {
+    const notes = buildReleaseNotes({
+      branch: 'main',
+      tag: 'v1.2.3',
+      fromRef: 'v1.2.2',
+      toRef: 'HEAD',
+      commits: [
+        { subject: 'fix: patch parser edge case', body: '' },
+        { subject: 'chore(deps): bump glob to 10.5.0', body: '' },
+        { subject: 'feat: add release summary output', body: '' },
+      ],
+    });
+
+    expect(notes).toContain('## Highlights');
+    expect(notes).toContain('## Fixes');
+    expect(notes).toContain('## Dependencies');
+    expect(notes).not.toContain('## Breaking Changes');
+
+    const highlightsIndex = notes.indexOf('## Highlights');
+    const fixesIndex = notes.indexOf('## Fixes');
+    const depsIndex = notes.indexOf('## Dependencies');
+    expect(highlightsIndex).toBeLessThan(fixesIndex);
+    expect(fixesIndex).toBeLessThan(depsIndex);
+  });
+});


### PR DESCRIPTION
Closes #303\n\n## Summary\n- add release notes generator with deterministic sections: Highlights, Fixes, Dependencies, Breaking Changes\n- omit empty sections automatically\n- include branch and git range context in generated notes\n- wire publish_release.yml to generate RELEASE_NOTES.md and publish releases using --notes-file\n- add unit test for section ordering and empty-section omission\n\nNo auto-merge performed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds deterministic, branch‑aware release notes and wires them into the release workflow. Notes include Highlights, Fixes, Dependencies, and Breaking Changes, with empty sections omitted. Closes #303.

- **New Features**
  - Generate notes from the last tag to `HEAD`, with branch, tag, and range in the header.
  - Deterministic section order; empty sections are skipped.
  - `publish_release.yml` writes `RELEASE_NOTES.md` and passes it to `gh release create --notes-file`.
  - Unit test covers section ordering and empty-section omission.

<sup>Written for commit ff0296d00c7e2f883c2e8f2ea3d87a3776b76e65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

