### PR TITLE
ci: add workflow YAML validation

### DIFF
--- a/.github/workflows/lint_workflows.yml
+++ b/.github/workflows/lint_workflows.yml
@@ -29,4 +29,4 @@ jobs:
 
       - name: Validate workflow YAML syntax
         run: |
-          yamllint -d "{extends: default, rules: {line-length: disable, truthy: disable, comments: disable}}" .github/workflows
+          yamllint -d "{extends: default, rules: {document-start: disable, line-length: disable, truthy: disable, comments: disable, comments-indentation: disable, new-lines: disable, trailing-spaces: disable}}" .github/workflows

--- a/.github/workflows/lint_workflows.yml
+++ b/.github/workflows/lint_workflows.yml
@@ -18,3 +18,15 @@ jobs:
         with:
           flags: >-
             -ignore "dist/index.js"
+
+      - name: Set up Python for YAML validation
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Install yamllint
+        run: pip install yamllint
+
+      - name: Validate workflow YAML syntax
+        run: |
+          yamllint -d "{extends: default, rules: {line-length: disable, truthy: disable, comments: disable}}" .github/workflows


### PR DESCRIPTION
Closes #297\n\n## Summary\n- keep existing ctionlint CI job\n- add YAML validation to .github/workflows using yamllint\n- fail PR checks early on malformed workflow YAML\n\n## Notes\n- Change is isolated to .github/workflows/lint_workflows.yml to minimize merge conflicts.\n- No auto-merge performed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add YAML validation to the workflow lint job using `yamllint` with a relaxed, syntax-focused ruleset so malformed `.github/workflows` files fail PR checks early. Keeps the existing `actionlint` check and addresses #297.

<sup>Written for commit 2b7e8667856f89ccb6b9663dd4890549ecdb496f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

