### PR TITLE
ci: standardize Yarn 4.12.0 in workflows

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -24,6 +24,11 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
+      - name: Pin Yarn version
+        run: |
+          corepack prepare yarn@4.12.0 --activate
+          yarn --version
+
       - name: Install dependencies
         env:
           YARN_ENABLE_HARDENED_MODE: "0"

--- a/.github/workflows/dependency_audit.yml
+++ b/.github/workflows/dependency_audit.yml
@@ -23,6 +23,11 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
+      - name: Pin Yarn version
+        run: |
+          corepack prepare yarn@4.12.0 --activate
+          yarn --version
+
       - name: Install dependencies
         env:
           YARN_ENABLE_HARDENED_MODE: "0"

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -23,6 +23,11 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
+      - name: Pin Yarn version
+        run: |
+          corepack prepare yarn@4.12.0 --activate
+          yarn --version
+
       - name: Install dependencies
         env:
           YARN_ENABLE_HARDENED_MODE: "0"

--- a/.github/workflows/todo.yml
+++ b/.github/workflows/todo.yml
@@ -58,6 +58,11 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
+      - name: Pin Yarn version
+        run: |
+          corepack prepare yarn@4.12.0 --activate
+          yarn --version
+
       - name: Resolve repo token strategy
         run: |
           if [ -z "${{ secrets.PERSONAL_ACCESS_TOKEN }}" ]; then

--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ See the [examples](examples/) directory for a complete workflow configuration.
 
 Set `OPENAI_API_KEY` or `GEMINI_API_KEY` secrets based on your chosen provider.
 
+For consistent local tooling, use the same pinned Yarn version as CI:
+
+```bash
+corepack enable
+corepack prepare yarn@4.12.0 --activate
+```
+
 ### 2. Run the CLI locally
 
 Use the bundled command-line interface to scan a directory on your machine and


### PR DESCRIPTION
Closes #296\n\n## Summary\n- pin Yarn to 4.12.0 in all workflows that execute Yarn commands\n- keep corepack enable and add explicit corepack prepare yarn@4.12.0 --activate\n- print yarn --version in CI for traceability\n- document matching local setup commands in README\n\n## Conflict minimization\n- isolated changes to workflow files and README only\n- no source/runtime code changes\n\nNo auto-merge performed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes CI on Yarn 4.12.0 to remove toolchain drift and make builds reproducible (closes #296). Adds explicit `corepack prepare yarn@4.12.0 --activate`, prints `yarn --version` for traceability, and documents matching local setup in the README; no source/runtime changes.

- **Migration**
  - Run `corepack enable`
  - Run `corepack prepare yarn@4.12.0 --activate`

<sup>Written for commit b284b96a88801b5369c43866b564ac9b754b9b7c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

